### PR TITLE
ck concordances, placetype local, and more

### DIFF
--- a/data/856/700/79/85670079.geojson
+++ b/data/856/700/79/85670079.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00181,
-    "geom:area_square_m":21033617.6453,
+    "geom:area_square_m":21033725.825422,
     "geom:bbox":"-158.297353,-20.019708,-158.078318,-19.810642",
     "geom:latitude":-19.993041,
     "geom:longitude":-158.110523,
@@ -23,7 +23,7 @@
     "mps:latitude":-19.997648,
     "mps:longitude":-158.107082,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:ara_x_preferred":[
@@ -249,11 +249,13 @@
         "gn:id":-99,
         "gp:id":24549674,
         "hasc:id":"CK.",
+        "iso:code_pseudo":"CK-AT",
         "qs_pg:id":1263410,
         "wd:id":"Q755982"
     },
+    "wof:concordances_official":"iso:code_pseudo",
     "wof:country":"CK",
-    "wof:geomhash":"a5d59332ff46aacd0b2472a90f335f1d",
+    "wof:geomhash":"5ce42984c6b3d957dd86a627bb907fd5",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -270,7 +272,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636494823,
+    "wof:lastmodified":1695884285,
     "wof:name":"Atiu",
     "wof:parent_id":85632481,
     "wof:placetype":"region",

--- a/data/856/700/81/85670081.geojson
+++ b/data/856/700/81/85670081.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000524,
-    "geom:area_square_m":6121436.631214,
+    "geom:area_square_m":6121512.653383,
     "geom:bbox":"-158.955556,-19.26922,-158.898508,-19.237319",
     "geom:latitude":-19.252015,
     "geom:longitude":-158.925041,
@@ -23,7 +23,7 @@
     "mps:latitude":-19.249911,
     "mps:longitude":-158.946232,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:ara_x_preferred":[
@@ -258,11 +258,13 @@
         "gn:id":-99,
         "gp:id":24549676,
         "hasc:id":"CK.",
+        "iso:code_pseudo":"CK-AI",
         "qs_pg:id":135923,
         "wd:id":"Q223379"
     },
+    "wof:concordances_official":"iso:code_pseudo",
     "wof:country":"CK",
-    "wof:geomhash":"576be4f634376f0ee74fd4adf8910530",
+    "wof:geomhash":"190d68284a67a7f9f722a6e1d5bfb1ba",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -279,7 +281,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690866751,
+    "wof:lastmodified":1695884281,
     "wof:name":"Aitutaki",
     "wof:parent_id":85632481,
     "wof:placetype":"region",

--- a/data/856/700/85/85670085.geojson
+++ b/data/856/700/85/85670085.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003378,
-    "geom:area_square_m":38752404.526578,
+    "geom:area_square_m":38752371.345222,
     "geom:bbox":"-157.968699,-21.938897,-157.887074,-21.877537",
     "geom:latitude":-21.911209,
     "geom:longitude":-157.929398,
@@ -23,7 +23,7 @@
     "mps:latitude":-21.910592,
     "mps:longitude":-157.932702,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:ara_x_preferred":[
@@ -255,11 +255,13 @@
         "gn:id":-99,
         "gp:id":24549672,
         "hasc:id":"CK.",
+        "iso:code_pseudo":"CK-MG",
         "qs_pg:id":131886,
         "wd:id":"Q1359323"
     },
+    "wof:concordances_official":"iso:code_pseudo",
     "wof:country":"CK",
-    "wof:geomhash":"fc865403549017338f8f97e7d5fa5de9",
+    "wof:geomhash":"e2cab3f2e9697a94995a1cde5b871d44",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -276,7 +278,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690866751,
+    "wof:lastmodified":1695884285,
     "wof:name":"Mangaia",
     "wof:parent_id":85632481,
     "wof:placetype":"region",

--- a/data/856/700/89/85670089.geojson
+++ b/data/856/700/89/85670089.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005582,
-    "geom:area_square_m":64344089.917758,
+    "geom:area_square_m":64343962.583953,
     "geom:bbox":"-159.846262,-21.254327,-159.736033,-21.18613",
     "geom:latitude":-21.219344,
     "geom:longitude":-159.78651,
@@ -23,7 +23,7 @@
     "mps:latitude":-21.21605,
     "mps:longitude":-159.785461,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:ara_x_preferred":[
@@ -294,11 +294,13 @@
         "gn:id":-99,
         "gp:id":24549675,
         "hasc:id":"CK.",
+        "iso:code_pseudo":"CK-RT",
         "qs_pg:id":976983,
         "wd:id":"Q471793"
     },
+    "wof:concordances_official":"iso:code_pseudo",
     "wof:country":"CK",
-    "wof:geomhash":"dd1712c3a1d2c0ea577cd95ea67bdd5c",
+    "wof:geomhash":"dd2798d9204a5a3b636304b418c4b994",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -315,7 +317,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690866751,
+    "wof:lastmodified":1695884286,
     "wof:name":"Rarotonga",
     "wof:parent_id":85632481,
     "wof:placetype":"region",

--- a/data/856/700/93/85670093.geojson
+++ b/data/856/700/93/85670093.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00174,
-    "geom:area_square_m":20243391.06936,
+    "geom:area_square_m":20243652.07359,
     "geom:bbox":"-157.742136,-19.85589,-157.707224,-19.767185",
     "geom:latitude":-19.810705,
     "geom:longitude":-157.721162,
@@ -23,7 +23,7 @@
     "mps:latitude":-19.810625,
     "mps:longitude":-157.724335,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:ara_x_preferred":[
@@ -241,11 +241,13 @@
         "gn:id":-99,
         "gp:id":24549667,
         "hasc:id":"CK.",
+        "iso:code_pseudo":"CK-MO",
         "qs_pg:id":131586,
         "wd:id":"Q596542"
     },
+    "wof:concordances_official":"iso:code_pseudo",
     "wof:country":"CK",
-    "wof:geomhash":"369fd6049afb82db81478ddca747601a",
+    "wof:geomhash":"33320ed281585150df7034a76101fcad",
     "wof:hierarchy":[
         {
             "continent_id":-1,
@@ -261,7 +263,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690866750,
+    "wof:lastmodified":1695884286,
     "wof:name":"Mitiaro",
     "wof:parent_id":-1,
     "wof:placetype":"region",

--- a/data/856/700/97/85670097.geojson
+++ b/data/856/700/97/85670097.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001092,
-    "geom:area_square_m":12677772.032249,
+    "geom:area_square_m":12677697.552299,
     "geom:bbox":"-157.349355,-20.179132,-157.312815,-20.137384",
     "geom:latitude":-20.157879,
     "geom:longitude":-157.332348,
@@ -23,7 +23,7 @@
     "mps:latitude":-20.157715,
     "mps:longitude":-157.332,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:ara_x_preferred":[
@@ -246,11 +246,13 @@
         "gn:id":-99,
         "gp:id":24549666,
         "hasc:id":"CK.",
+        "iso:code_pseudo":"CK-MK",
         "qs_pg:id":135906,
         "wd:id":"Q511978"
     },
+    "wof:concordances_official":"iso:code_pseudo",
     "wof:country":"CK",
-    "wof:geomhash":"045077fa4a7b373813f4c1b801910264",
+    "wof:geomhash":"3a769c1f56028c594602cc9c6a37bfbd",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -267,7 +269,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690866751,
+    "wof:lastmodified":1695884286,
     "wof:name":"Mauke",
     "wof:parent_id":85632481,
     "wof:placetype":"region",

--- a/data/856/701/01/85670101.geojson
+++ b/data/856/701/01/85670101.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001247,
-    "geom:area_square_m":14594214.017971,
+    "geom:area_square_m":14594078.843704,
     "geom:bbox":"-159.802317,-18.887953,-159.761383,-18.828953",
     "geom:latitude":-18.858395,
     "geom:longitude":-159.786601,
@@ -23,7 +23,7 @@
     "mps:latitude":-18.861783,
     "mps:longitude":-159.790012,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:afr_x_preferred":[
@@ -173,10 +173,12 @@
         "gn:id":-99,
         "gp:id":24549670,
         "hasc:id":"CK.",
+        "iso:code_pseudo":"CK-PL",
         "qs_pg:id":774981
     },
+    "wof:concordances_official":"iso:code_pseudo",
     "wof:country":"CK",
-    "wof:geomhash":"6617ff57474c444302d961f89742ab28",
+    "wof:geomhash":"51f000d5e63487fef9936f93f81c7299",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -193,7 +195,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636494822,
+    "wof:lastmodified":1695884285,
     "wof:name":"Palmerston",
     "wof:parent_id":85632481,
     "wof:placetype":"region",

--- a/data/856/701/05/85670105.geojson
+++ b/data/856/701/05/85670105.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000287,
-    "geom:area_square_m":3478445.863423,
+    "geom:area_square_m":3478460.968712,
     "geom:bbox":"-165.824737,-13.281345,-163.082387,-10.880141",
     "geom:latitude":-11.030518,
     "geom:longitude":-165.719517,
@@ -23,7 +23,7 @@
     "mps:latitude":-10.945654,
     "mps:longitude":-165.809355,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:ara_x_preferred":[
@@ -253,11 +253,13 @@
         "gn:id":-99,
         "gp:id":24549668,
         "hasc:id":"CK.",
+        "iso:code_pseudo":"CK-PK",
         "qs_pg:id":131615,
         "wd:id":"Q1130629"
     },
+    "wof:concordances_official":"iso:code_pseudo",
     "wof:country":"CK",
-    "wof:geomhash":"8e38efba11bb6071b0772d68fc07fd0f",
+    "wof:geomhash":"8f0960438e065d8204787ec9ff398808",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -274,7 +276,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690866750,
+    "wof:lastmodified":1695884285,
     "wof:name":"Pukapuka",
     "wof:parent_id":85632481,
     "wof:placetype":"region",

--- a/data/856/701/11/85670111.geojson
+++ b/data/856/701/11/85670111.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000118,
-    "geom:area_square_m":1438064.660997,
+    "geom:area_square_m":1438021.841473,
     "geom:bbox":"-161.088002,-10.04461,-161.070058,-10.027439",
     "geom:latitude":-10.035822,
     "geom:longitude":-161.080727,
@@ -23,7 +23,7 @@
     "mps:latitude":-10.035673,
     "mps:longitude":-161.080863,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:ara_x_preferred":[
@@ -241,11 +241,13 @@
         "gn:id":-99,
         "gp:id":24549673,
         "hasc:id":"CK.",
+        "iso:code_pseudo":"CK-RK",
         "qs_pg:id":775065,
         "wd:id":"Q1345121"
     },
+    "wof:concordances_official":"iso:code_pseudo",
     "wof:country":"CK",
-    "wof:geomhash":"985bdd63ba161f87a9d57c3f2687cd26",
+    "wof:geomhash":"83da69db069c1be87710aaf846caa48a",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -260,7 +262,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690866750,
+    "wof:lastmodified":1695884285,
     "wof:name":"Rakahanga",
     "wof:parent_id":-1,
     "wof:placetype":"region",

--- a/data/856/701/15/85670115.geojson
+++ b/data/856/701/15/85670115.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000199,
-    "geom:area_square_m":2423117.247887,
+    "geom:area_square_m":2422828.446068,
     "geom:bbox":"-160.996409,-10.422784,-160.9381,-10.371515",
     "geom:latitude":-10.39142,
     "geom:longitude":-160.972527,
@@ -23,7 +23,7 @@
     "mps:latitude":-10.390599,
     "mps:longitude":-160.972969,
     "mz:hierarchy_label":1,
-    "mz:is_current":-1,
+    "mz:is_current":1,
     "mz:max_zoom":11.0,
     "mz:min_zoom":11.0,
     "name:ara_x_preferred":[
@@ -244,11 +244,13 @@
         "gn:id":-99,
         "gp:id":24549680,
         "hasc:id":"CK.",
+        "iso:code_pseudo":"CK-MN",
         "qs_pg:id":135927,
         "wd:id":"Q967796"
     },
+    "wof:concordances_official":"iso:code_pseudo",
     "wof:country":"CK",
-    "wof:geomhash":"04d8b692326b31cecb5830c8122b4f8c",
+    "wof:geomhash":"90e025a625db3d9664b3f6bf5ca0b192",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -263,7 +265,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636494822,
+    "wof:lastmodified":1695884285,
     "wof:name":"Manihiki",
     "wof:parent_id":-1,
     "wof:placetype":"region",

--- a/data/856/701/19/85670119.geojson
+++ b/data/856/701/19/85670119.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001321,
-    "geom:area_square_m":16132643.49385,
+    "geom:area_square_m":16132442.188397,
     "geom:bbox":"-158.064809,-9.113946,-157.908762,-8.94671",
     "geom:latitude":-8.993401,
     "geom:longitude":-157.980211,
@@ -165,10 +165,12 @@
         "gn:id":-99,
         "gp:id":24549679,
         "hasc:id":"CK.",
+        "iso:code_pseudo":"CK-TN",
         "qs_pg:id":135926
     },
+    "wof:concordances_official":"iso:code_pseudo",
     "wof:country":"CK",
-    "wof:geomhash":"b7ea191a4aac349e2a5bef162f75a751",
+    "wof:geomhash":"dea17c8de9309cc6ccdb8dcfaab7686a",
     "wof:hierarchy":[
         {
             "continent_id":102191583,
@@ -185,7 +187,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636494822,
+    "wof:lastmodified":1695884778,
     "wof:name":"Penrhyn",
     "wof:parent_id":85632481,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.